### PR TITLE
FNX-347: Add Claude Code review agent configuration

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -1,0 +1,58 @@
+# Claude Code Review Prompt
+
+You are reviewing pull requests for dm-core, the DataMapper ORM core library
+(CustomInk fork). Ruby gem using RSpec 1.x (legacy, NOT modern RSpec 3).
+Yardstick enforces 100% documentation coverage.
+
+**Only comment when you have actionable feedback. Never post "looks good",
+"no issues found", or summary-only comments.**
+
+## PR Format
+
+- PR title MUST start with a JIRA ticket reference:
+  `FNX-123: Title describing the task/change`
+
+## API Visibility Tiers
+
+Every public or semipublic method MUST carry a `@api` YARD tag:
+- `@api public` — stable public interface; changes break all consumers
+- `@api semipublic` — adapter/plugin interface; changes affect adapter gems
+- `@api private` — internal implementation detail
+
+Flag missing `@api` tags (Yardstick enforces 100% coverage). A change from
+public/semipublic to a different tier is breaking and needs justification.
+
+## Backwards Compatibility
+
+- `lib/dm-core/backwards.rb` maintains deprecation shims — removing a
+  method with an existing shim is breaking
+- New deprecations must add a shim using `DataMapper::Support::Deprecate`
+- Verify deprecation messages point to the correct replacement
+
+## Shared Spec Compatibility
+
+- Shared specs in `lib/dm-core/spec/shared/` are consumed by every adapter
+  gem — changes have wide blast radius
+- Modifications to shared spec interfaces require adapter gem updates
+- Deletions from shared specs can silently break adapter test suites
+
+## RSpec 1.x Syntax
+
+This repo uses RSpec 1.3.x. Do NOT introduce RSpec 3 syntax:
+- Use `Spec::Runner.configure`, not `RSpec.configure`
+- Use `be_true`/`be_false`, not `be_truthy`/`be_falsey`
+- Use `stub!`, not `allow(...).to receive`
+
+## Identity Map Correctness
+
+- Object identity (`equal?`) must be preserved for repeated loads
+- `DataMapper.finalize` must be called correctly in tests
+- Persistence state transitions (Transient -> Clean -> Dirty -> Clean)
+  must not skip states
+
+## Review Behavior
+
+- Distinguish **blocking** (must fix before merge) from **suggestion**
+- Group related issues into a single review comment
+- Reference specific lines using GitHub line-link format
+- If the entire PR looks good, do not post a comment at all

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch PR diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr diff "${{ github.event.pull_request.number }}" > /tmp/pr-diff.patch
+
       - name: Build review prompt
         id: prompt
         run: |
@@ -47,11 +53,18 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Claude Code Review
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }}.
+            The full diff is in /tmp/pr-diff.patch — Read that file first.
+            Do NOT run gh pr diff or git diff to re-fetch it.
+            Use Read on source files if you need more context beyond the diff.
+            Post inline review comments and stop.
+
             Review this pull request using the following guidelines:
 
             ${{ steps.prompt.outputs.REVIEW_PROMPT }}
-          claude_args: "--model claude-opus-4-6 --max-turns 3"
+          claude_args: '--model claude-opus-4-6 --max-turns 10 --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,12 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
@@ -12,7 +18,11 @@ permissions:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,3 @@ jobs:
 
             ${{ steps.prompt.outputs.REVIEW_PROMPT }}
           claude_args: "--model claude-opus-4-6 --max-turns 3"
-          plugin_marketplaces: |
-            https://github.com/customink/claude-marketplace.git
-          plugins: |
-            ada@customink-plugins

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,51 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build review prompt
+        id: prompt
+        run: |
+          DELIMITER="PROMPT_EOF_$(uuidgen)"
+          {
+            echo "REVIEW_PROMPT<<${DELIMITER}"
+            for f in CLAUDE.md AGENTS.md; do
+              if [ -f "$f" ]; then
+                cat "$f"
+                echo ""
+              fi
+            done
+            cat .claude/review-prompt.md
+            echo "${DELIMITER}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request using the following guidelines:
+
+            ${{ steps.prompt.outputs.REVIEW_PROMPT }}
+          claude_args: "--model claude-opus-4-6 --max-turns 3"
+          plugin_marketplaces: |
+            https://github.com/customink/claude-marketplace.git
+          plugins: |
+            ada@customink-plugins

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,21 +20,31 @@ jobs:
   review:
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
           fetch-depth: 0
 
       - name: Fetch PR diff
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr diff "${{ github.event.pull_request.number }}" > /tmp/pr-diff.patch
+          gh pr diff "${{ steps.pr.outputs.number }}" > /tmp/pr-diff.patch
 
       - name: Build review prompt
         id: prompt
@@ -58,7 +68,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            You are reviewing PR #${{ github.event.pull_request.number }}.
+            You are reviewing PR #${{ steps.pr.outputs.number }}.
             The full diff is in /tmp/pr-diff.patch — Read that file first.
             Do NOT run gh pr diff or git diff to re-fetch it.
             Use Read on source files if you need more context beyond the diff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+## Project Overview
+
+dm-core is the core library of DataMapper, a Ruby ORM. Provides property definitions, query building, associations, identity mapping, dirty tracking, lazy loading, and adapter-based data store abstraction. Version 1.3.0.beta. CustomInk fork maintained by Fenix team, Tier 4.
+
+## Tech Stack
+
+- **Language**: Ruby
+- **Type**: Ruby gem (`dm-core`)
+- **Key deps**: addressable (~> 2.2.6), virtus (~> 0.5)
+- **Dev deps**: rake (~> 0.9.2), rspec (~> 1.3.2) -- NOTE: RSpec 1.x, not modern RSpec 3.x
+- **Adapter ecosystem**: Pluggable via dm-do-adapter + database-specific gems. Ships with InMemoryAdapter.
+
+## Development Setup
+
+```bash
+bundle install
+ADAPTER=sqlite bundle install   # Optional: specify adapter for integration testing
+```
+
+## Testing
+
+```bash
+bundle exec rake spec           # Run all specs
+```
+
+Uses RSpec 1.3.x. Specs organized by API visibility: `spec/public/`, `spec/semipublic/`, `spec/unit/`. Shared specs in `lib/dm-core/spec/shared/` exported for adapter/plugin gems.
+
+## Architecture & Key Conventions
+
+- **Resource pattern**: Models include `DataMapper::Resource`, declare properties inline
+- **Repository/Adapter pattern**: `DataMapper.setup(:name, uri)` registers adapters
+- **Identity Map**: Same DB row always returns same Ruby object within repository block
+- **Persistence state machine**: Transient -> Clean -> Dirty -> Clean in `resource/persistence_state/`
+- **Finalization**: `DataMapper.finalize` must be called after all models loaded
+- **API visibility tiers**: `public`, `semipublic`, `private` (reflected in specs and YARD tags)
+
+## Review Focus Areas
+
+- **API visibility**: Check `@api` YARD tags -- public changes are breaking
+- **Shared spec compatibility**: Changes affect downstream adapter/plugin gems
+- **Backwards compatibility**: `backwards.rb` maintains shims
+- **RSpec 1.x syntax**: Uses `Spec::Runner`, not `RSpec.describe`
+- **Documentation**: Yardstick enforces 100% coverage threshold


### PR DESCRIPTION
## Stakeholder Overview

Adds a custom Claude Code review agent configuration to this repository. This replaces the generic code-review plugin with a repo-specific review prompt that focuses on architectural, domain-specific, and cross-file concerns — excluding rules already enforced by automated linters.

_For more context, see relevant [Guru](https://app.getguru.com/) documentation._

## Risk Estimate

✅ Negligible risk!

This only adds/updates GitHub Actions workflow configuration and a review prompt file. No application code is changed.

## Changes

- **`.claude/review-prompt.md`** — New file with repo-specific review guidelines covering domain logic, architectural patterns, cross-file consistency, and security concerns. Excludes all rules already enforced by linters.
- **`.github/workflows/claude-code-review.yml`** — Updated workflow to use Opus model, CustomInk plugin marketplace, full git history (`fetch-depth: 0`), and a build step that concatenates `CLAUDE.md` + `review-prompt.md` into the review prompt.

## Project Link

[FNX-347](https://customink.atlassian.net/browse/FNX-347)

[FNX-347]: https://customink.atlassian.net/browse/FNX-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ