### PR TITLE
FNX-353: Make Claude Code review model configurable via repo variable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,20 +9,6 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  workflow_dispatch:
-    inputs:
-      model:
-        description: "Claude model to use (overrides CLAUDE_REVIEW_MODEL variable)"
-        required: false
-        type: choice
-        default: ''
-        options:
-          - ''
-          - sonnet
-          - 'sonnet[1m]'
-          - opus
-          - 'opus[1m]'
-          - haiku
 
 permissions:
   contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,9 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number
@@ -58,7 +61,9 @@ jobs:
                 echo ""
               fi
             done
-            cat .claude/review-prompt.md
+            if [ -f ".claude/review-prompt.md" ]; then
+              cat .claude/review-prompt.md
+            fi
             echo "${DELIMITER}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,6 +9,20 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model to use (overrides CLAUDE_REVIEW_MODEL variable)"
+        required: false
+        type: choice
+        default: ''
+        options:
+          - ''
+          - sonnet
+          - 'sonnet[1m]'
+          - opus
+          - 'opus[1m]'
+          - haiku
 
 permissions:
   contents: read
@@ -72,10 +86,11 @@ jobs:
         run: |
           # Priority: workflow_dispatch input > repo variable > omit (action default: Sonnet)
           MODEL="${{ inputs.model || vars.CLAUDE_REVIEW_MODEL }}"
+          ALLOWED_TOOLS='Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)'
           if [ -n "$MODEL" ]; then
-            echo "value=--model ${MODEL} --max-turns 3" >> "$GITHUB_OUTPUT"
+            echo "value=--model ${MODEL} --max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"
           else
-            echo "value=--max-turns 3" >> "$GITHUB_OUTPUT"
+            echo "value=--max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,11 +70,9 @@ jobs:
       - name: Resolve claude_args
         id: args
         run: |
-          # Priority: repo variable > omit (action default: Sonnet)
-          MODEL="${{ vars.CLAUDE_REVIEW_MODEL }}"
           ALLOWED_TOOLS='Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)'
-          if [ -n "$MODEL" ]; then
-            echo "value=--model ${MODEL} --max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ vars.CLAUDE_REVIEW_MODEL }}" ]; then
+            echo "value=--model ${{ vars.CLAUDE_REVIEW_MODEL }} --max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"
           else
             echo "value=--max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,6 +62,17 @@ jobs:
             echo "${DELIMITER}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve claude_args
+        id: args
+        run: |
+          # Priority: workflow_dispatch input > repo variable > omit (action default: Sonnet)
+          MODEL="${{ inputs.model || vars.CLAUDE_REVIEW_MODEL }}"
+          if [ -n "$MODEL" ]; then
+            echo "value=--model ${MODEL} --max-turns 3" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=--max-turns 3" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Claude Code Review
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
@@ -77,4 +88,4 @@ jobs:
             Review this pull request using the following guidelines:
 
             ${{ steps.prompt.outputs.REVIEW_PROMPT }}
-          claude_args: '--model claude-opus-4-6 --max-turns 10 --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)"'
+          claude_args: "${{ steps.args.outputs.value }}"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Resolve claude_args
         id: args
         run: |
-          # Priority: workflow_dispatch input > repo variable > omit (action default: Sonnet)
-          MODEL="${{ inputs.model || vars.CLAUDE_REVIEW_MODEL }}"
+          # Priority: repo variable > omit (action default: Sonnet)
+          MODEL="${{ vars.CLAUDE_REVIEW_MODEL }}"
           ALLOWED_TOOLS='Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)'
           if [ -n "$MODEL" ]; then
             echo "value=--model ${MODEL} --max-turns 10 --allowedTools \"${ALLOWED_TOOLS}\"" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Stakeholder Overview

Makes the Claude Code review workflow model configurable via a `CLAUDE_REVIEW_MODEL` GitHub repo variable instead of being hardcoded, allowing teams to switch models without code changes.

_For more context, see relevant [Guru](https://app.getguru.com/) documentation._

## Risk Estimate

✅ Negligible risk!

## Changes

- Added a `Resolve claude_args` step before the `Claude Code Review` step in the workflow
- Model selection priority: `workflow_dispatch` input > `CLAUDE_REVIEW_MODEL` repo variable > action default (Sonnet)
- Replaced hardcoded `claude_args` with the dynamically resolved value

## Project Link

- [FNX-353](https://customink.atlassian.net/browse/FNX-353)

[FNX-353]: https://customink.atlassian.net/browse/FNX-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ